### PR TITLE
Minor changes based on reviews of oxcaml/oxcaml#4769

### DIFF
--- a/otherlibs/systhreads/st_pthreads.h
+++ b/otherlibs/systhreads/st_pthreads.h
@@ -77,7 +77,7 @@ typedef struct {
   custom_condvar is_free;         /* signaled when free */
 } st_masterlock;
 
-/* Returns non-zero on failure */
+/* Initializes but does not lock a masterlock. Returns non-zero on failure */
 static int st_masterlock_init(st_masterlock * m)
 {
   int rc;
@@ -88,8 +88,8 @@ static int st_masterlock_init(st_masterlock * m)
     if (rc != 0) goto out_err2;
     m->init = 1;
   }
-  m->busy = 1;
-  m->last_locked_by = pthread_self();
+  m->busy = 0;
+  m->last_locked_by = pthread_self(); /* Here "initialized by". */
   atomic_store_release(&m->waiters, 0);
   return 0;
 

--- a/runtime/signals.c
+++ b/runtime/signals.c
@@ -181,14 +181,10 @@ CAMLexport void caml_record_signal(int signal_number)
 
 static void caml_enter_blocking_section_default(void)
 {
-  caml_bt_exit_ocaml();
-  caml_release_domain_lock();
 }
 
 static void caml_leave_blocking_section_default(void)
 {
-  caml_acquire_domain_lock();
-  caml_bt_enter_ocaml();
 }
 
 CAMLexport void (*caml_enter_blocking_section_hook)(void) =
@@ -201,6 +197,8 @@ static int check_pending_actions(caml_domain_state * dom_st);
 CAMLexport void caml_enter_blocking_section_no_pending(void)
 {
   caml_enter_blocking_section_hook ();
+  caml_bt_exit_ocaml();
+  caml_release_domain_lock();
 }
 
 CAMLexport void caml_enter_blocking_section(void)
@@ -230,6 +228,9 @@ CAMLexport void caml_leave_blocking_section(void)
   int saved_errno;
   /* Save the value of errno (PR#5982). */
   saved_errno = errno;
+
+  caml_acquire_domain_lock();
+  caml_bt_enter_ocaml();
   caml_leave_blocking_section_hook ();
   Caml_check_caml_state();
 


### PR DESCRIPTION
- Move the domain-lock/backup thread stuff out of the blocking section hooks, since they are necessarily shared by all implementations.
- Change `st_masterlock_init` so it doesn't take the lock.
- Add some comments to domain.c.